### PR TITLE
Fixed card display option crash

### DIFF
--- a/app/src/main/java/org/liberty/android/fantastischmemo/scheduler/DefaultScheduler.java
+++ b/app/src/main/java/org/liberty/android/fantastischmemo/scheduler/DefaultScheduler.java
@@ -171,7 +171,7 @@ public class DefaultScheduler implements Scheduler {
 
     @Override
     public boolean isCardFavourite(LearningData data) {
-        return data.getFavourite()== 1;
+        return data.getFavourite() == Integer.valueOf(1);
     }
     @Override
     public boolean isCardForReview(LearningData data) {


### PR DESCRIPTION
Forgot to refer to the bug : #96

- The app was crashing every time the user was trying to display the
list of cards within their current database
- The error was caused because we were comparing an Integer object with
an int
- It was fixed by comparing the data's Integer object to an
Integer object with value of 1